### PR TITLE
Improve readability and fix small typos on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # ApplicationAction
 
-Tiny on the code, heavy on the concept. ApplicationAction is an opiniated concept extend of Rails.
+Tiny on code, heavy on concept. ApplicationAction is an opiniated concept extend of the Ruby on Rails framework.
 
-ApplicationAction is an useful `Action` pattern I found myself following for many years among many Rails projects so I hope its usefull for you too. It mimics `ApplicationRecord`'s interface to the `Action`s your applications execute. Its easy to extent, to test, to compose and reuse.
+ApplicationAction is an useful `Action` pattern I found myself following for many years among many Rails projects so I hope its usefull for you too. It mimics `ApplicationRecord`'s interface to the `Action`s your applications execute. Its easy to extent, test, compose and reuse.
 
-This is all the code. All of it:
+This is the code. All of it:
 
 ```ruby
 class ApplicationAction
@@ -30,7 +30,7 @@ end
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add this line to your Gemfile:
 
 ```ruby
 gem 'application_action'
@@ -71,7 +71,7 @@ class SomeAction < ApplicationAction
 end
 ```
 
-Then, whenever suits you, you can call the action like this:
+Then, whenever suits you, call the action like this:
 
 ```ruby
 action = SomeAction.new(foo: foo, bar: bar)
@@ -86,15 +86,15 @@ Having being through all the "fat models, skinny controllers" eras, I find an `A
 
 ## Philosophy
 
-Think of `Action`s as one small state transition of your application. Its the representation of what your application do. So everytime an `Action` run, something changes and there are consequences. Each `Action` have a well-defined and validated scenario before run.
+Think of `Action`s as one small state transition of your application. It's the representation of what your application does. So everytime an `Action` run, something changes and there are consequences. Each `Action` have a well-defined and validated scenario before running.
 
 #### The business logic should not live in the models
 
-You heard the story before: `ActiveRecord` already do too much. The database interface, query, validations and relationships are more than enough.
+You heard the story before: `ActiveRecord` already does too much. The database interface, query, validations and relationships are more than enough.
 
-Model's should represent an entity stored at the database, a small piece of your entire application state. A single model or record should not handle complex operations, specially involving multiple models.
+Models should represent an entity stored at the database, a small piece of your entire application state. A single model or record should not handle complex operations, specially involving multiple models.
 
-Model's validations should only validate what is expected for every record, everytime. Some validations will only be applied in certain moments so these validations lives in an `Action`. [ActiveRecord's validations scope](https://guides.rubyonrails.org/active_record_validations.html#on) can handle simple scenarios but `Action`s validations is a better suit for complex logics.
+Models validations should only check what is expected for every record, everytime. Some validations will only be applied in certain moments so these validations lives in an `Action`. [ActiveRecord's validations scope](https://guides.rubyonrails.org/active_record_validations.html#on) can handle simple scenarios but `Action`s validations is a better suit for complex logics.
 
 #### The business logic should not live in controllers
 
@@ -102,15 +102,15 @@ Same here. Controller already handle request params and formats, response codes 
 
 #### Actions are important changes
 
-`Action`s should have heavy validations to make sure everything is ok before running. `Action`s are atomic, so you can't have half of it done. This will help with your database (and the whole app) consistency.
+`Action`s should have strict validations to make sure everything is ok before running. `Action`s are atomic, so you must have it completely done, or not done at all. This will help with your database (and the whole app) consistency.
 
 They should be well tested and you should be able to test every scenario without an integration test. You can unit test every `Action` validation and every change it makes when it runs.
 
 ### A Practical Example
 
-#### UberLike Logic
+#### Uber-like Logic
 
-Consider an Uber like app, where passengers requests trips and the nearest available driver is found. The driver can refuse the invite so the next driver should be invited. Driver also have a 1 minute timeout to respond the invitation, otherwise the invite expires and the next driver is invited. You can have some _DRY_ `Action`s like these:
+Consider an Uber-like app, where passengers request for trips and the nearest available driver is found. The driver can refuse the request, so the next driver should be requested. Driver also have a 1 minute timeout to respond the request, otherwise it expires and the next driver is called. You can have some _DRY_ `Action`s like these:
 
 1. Request Trip Action:
 
@@ -156,13 +156,13 @@ class FindTripDriver < ApplicationAction
   validates :nearest_driver, :trip, presence: true
 
   def nearest_driver
-    Driver.available.where(???).first
+    Driver.available.where(...).first
   end
 
   def run
     trip.update!(driver: nearest_driver)
     driver.update!(current_trip: trip)
-    invite = TripInvitation.create!(trip: trip, driver: driver).save
+    invite = TripInvitation.create!(trip: trip, driver: driver)
 
     Notifications::InviteDriverToTrip.new(invite: invite).send!
 
@@ -178,7 +178,7 @@ class FindTripDriver < ApplicationAction
 end
 ```
 
-3. Driver Reject the invite
+3. Driver Rejects the request
 
 ```ruby
 class DriverRejectTrip < ApplicationAction
@@ -204,13 +204,13 @@ class DriverRejectTrip < ApplicationAction
 end
 ```
 
-- Note how dead simple it is to test these actions.
+- Note how simple it is to test these actions.
 - You can call them at diferent Controllers, from `ActiveJob`s or **GraphQL Mutations**
 - Your life at the `rails console` will be a lot easer having a way to call these business logic directly. No need of api calls or web interface.
 
 ### Translating error messages
 
-As the `Action`s includes `ActiveModel::Model` you can have each action error message translated folowing this structure:
+As the `Action`s includes `ActiveModel::Model` you can have each action's error message get translated by following this structure:
 
 ```yml
 en:
@@ -231,7 +231,7 @@ en:
 
 The experience of building multiple web applications with Rails, including different environments like 100% web interface apps or API only (both REST & GraphQL) apps, a single product with a legacy monorepo maintained by a big team or multiple quickly built on demand projects, made it clear this commom gap of Rails on where to place some more complex business logic. I covered this gap in many different ways in the past. From **Fat Models** to **Fat Controllers**, sometimes as `PORO`s under the `lib` folder and sometimes with different names (as `Services` or `Runners`).
 
-It was after i built some React SPA's and got familiar with the [Flux](https://facebook.github.io/flux/) architecture to handle front-end's application state and later getting used to the [Redux](https://redux.js.org) implementation library that i shamelessly copied the name **Action** as i found its was a nice fit for the case of a Rails application as well.
+It was after i built some React SPA's and got familiar with the [Flux](https://facebook.github.io/flux/) architecture to handle front-end's application state and later getting used to the [Redux](https://redux.js.org) implementation library that i shamelessly copied the name **Action** as I found it's was a nice fit for the case of a Rails application as well.
 
 I could translate the [Redux's Core Concepts](https://redux.js.org/introduction/core-concepts) and [Principles](https://redux.js.org/introduction/three-principles) to a Rails. I can see the database as the entire application state, the single source of truth and one should avoid change the application's state without an `Action` (specially for big changes). Every `Action` have an explicit changelist on the state so its easy to track how the state was before running and how the state became after.
 
@@ -242,7 +242,3 @@ I could translate the [Redux's Core Concepts](https://redux.js.org/introduction/
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
-
-```
-
-```


### PR DESCRIPTION
Making some phrases easier to read, remove unecessary code on examples,
and fixing small typos.